### PR TITLE
chore(github): Auto close stale PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 14
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - dependencies
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed after being stale for a while.


### PR DESCRIPTION
Introducing stale bot configuration that will automatically label and close stale PRs for you. This will help sort out huge history of irrelevant PRs in the repo and keep it clean moving forward. Details about the bot: https://github.com/marketplace/stale

In this default configuration your PR will be first labeled as `stale` after 14 days of inactivity, then it will be closed after another 14 days of inactivity - total of 28 days without any commit/comment/pr update/etc. To prevent this you can remove `stale` label to reset staleness countdown.

Furthermore, by default PRs with labels `pinned`, `security` and `dependencies` (used by dependabot) are not checked for staleness. You can configure this for your self.

[_Created by Sourcegraph batch change `TarasZubreiFiverr/stale-bot`._](https://fiverr.sourcegraph.com/users/TarasZubreiFiverr/batch-changes/stale-bot)